### PR TITLE
Replace PySimpleGUI GUI with PySide6 interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ We always tried to make factors (probabilities, numbers, values, calculations, e
     1. traci (python package)
     2. sumolib (python package)
 - [Python 3](https://www.python.org/about/) (tested with version 3.11, 3.12, and 3.13)
-- [PySimpleGUI](https://www.pysimplegui.org/en/latest/) (for two GUIs; we remain with version 4 due to licensing)
+- [PySide6](https://doc.qt.io/qtforpython/) (Qt-based GUIs for configuration and simulation dashboards)
 - [Matplotlib](https://matplotlib.org) (for visualization of data during simulation)
 - [Transformers](https://huggingface.co/docs/transformers/installation)
 - XML, CSV (file formats) \
@@ -94,7 +94,7 @@ or
 ```console
 git clone https://github.com/M-Colley/pedsumo.git
 ```
-4. Install PySimpleGUI and Matplotlib. You can just execute 
+4. Install PySide6 and Matplotlib. You can just execute
 ```console
 pip install -r [path to requirements.txt of this project]
 ```
@@ -431,5 +431,5 @@ Remember to be careful because disabling these modes will make it more difficult
 ## Licenses
 - [SUMO](https://sumo.dlr.de/docs/Libraries_Licenses.html)
 - [Matplotlib](https://matplotlib.org/stable/users/project/license.html)
-- [PySimpleGUI](https://github.com/PySimpleGUI/PySimpleGUI/blob/master/license.txt)
+- [PySide6](https://doc.qt.io/qtforpython/licenses.html)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ pandas>=2.2.3
 numpy>=1.26.4
 sumolib>=1.24.0
 screeninfo
+PySide6>=6.7.3
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
   install_requires=[            # I get to this in a second
           'pandas',
           'numpy',
-          'PySimpleGUI',
+          'PySide6',
           'screeninfo',
           'matplotlib',
           'transformers',


### PR DESCRIPTION
## Summary
- replace the legacy PySimpleGUI-based configuration and simulation windows with new PySide6/Qt widgets and styling
- refresh GUI logic to work with Qt event processing, including pause/stop handling and adjustable configuration inputs
- update project dependencies and documentation to reference PySide6 instead of PySimpleGUI

## Testing
- python -m compileall SumoWithAVs/gui.py

------
https://chatgpt.com/codex/tasks/task_e_68d0fd5503d88332b791f55d8e6a2c7b